### PR TITLE
Redefinition error & field label's underscores

### DIFF
--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -285,7 +285,7 @@ class admin_controller
 			'LINK'	=> $link,
 		));
 
-		$this->build_preview($form_id, $form_id);
+		$this->build_preview($form_id);
 	}
 
 	function get_forums($form_id)
@@ -329,7 +329,7 @@ class admin_controller
 		return($row);
 	}
 
-	function build_preview($form_id, $form_id)
+	function build_preview($form_id)
 	{
 		$sql = 'SELECT id, form_id, ndx_order, name, hint, type, mandatory, options, forum_name, forum_id
 			FROM ' . $this->table_formcreator . ' m, ' . FORUMS_TABLE . " f

--- a/event/listener.php
+++ b/event/listener.php
@@ -180,13 +180,11 @@ class listener implements EventSubscriberInterface
 				$mandatory = "";
 			}
 
-			$temp_name = $row['name'];
-
-			$row['name'] = str_replace(' ', '_', $row['name']);
+			$field_name = str_replace(' ', '_', $row['name']);
 
 			// make things even easier to read //
-			$name = "name='templatefield_{$row['name']}'";
-			$id = "id='templatefield_{$row['name']}'";
+			$name = "name='templatefield_{$field_name}'";
+			$id = "id='templatefield_{$field_name}'";
 			$placeholder = "placeholder='{$row['hint']}' ";
 			$tabindex = "tabindex='{$row['ndx_order']}' ";
 
@@ -271,6 +269,7 @@ class listener implements EventSubscriberInterface
 
 	private function grab_form_data($forum_id)
 	{
+
 		$ret = $appform_post = $last_checked = $temp = '';
 		$name_length_max = $file_count = 0;
 		$form_data = $names = array();
@@ -321,8 +320,8 @@ class listener implements EventSubscriberInterface
 		foreach ($form_data as $row)
 		{
 			$name = "";
-			$row['name'] = str_replace(' ', '_', $row['name']);
-			$name = "templatefield_" . $row['name'];
+			$field_name = str_replace(' ', '_', $row['name']);
+			$name = "templatefield_" . $field_name;
 
 			if (isset($row['type']))
 			{


### PR DESCRIPTION
Fix redefinition of $form_id parameter in admin_controller.php
Add $field_name to store $row['name'] with spaces replaced with underscores. This retains the copy with spaces to be used for display labels. This also fixes an issue with values not showing after the form has been posted.